### PR TITLE
Fail the build on insufficient coverage, and say what it is

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,8 @@
+ThisBuild / coverageSummaryStmtLowThreshold := 30
+ThisBuild / coverageSummaryStmtHighThreshold := 90
+ThisBuild / coverageSummaryBranchLowThreshold := 100
+ThisBuild / coverageSummaryBranchHighThreshold := 100
+
 dynverSonatypeSnapshots := true
 dynverSeparator := "-"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.12.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.2")
-addSbtPlugin("io.h8.sbt" % "sbt-scoverage-summary" % "1.1.2")
+addSbtPlugin("io.h8.sbt" % "sbt-scoverage-summary" % "2.0.0")

--- a/test.sh
+++ b/test.sh
@@ -2,4 +2,4 @@
 
 set -euxo pipefail
 
-sbt "scalafmtSbtCheck; scalafmtCheckAll; cleanFull; +coverage; +test; +coverageSummary; +coverageAggregate"
+sbt "scalafmtSbtCheck; scalafmtCheckAll; cleanFull; +coverage; +test; +coverageSummary; +coverageAggregate; +coverageSummaryCheck"


### PR DESCRIPTION
## What changed

- `sbt-scoverage-summary` 1.1.2 → **2.0.0**
- thresholds declared per metric, since the old single `coverageSummaryLowThreshold` / `HighThreshold` pair no longer exists
- `+coverageSummaryCheck` appended to `test.sh`

## The finding

Measuring before choosing a threshold is what this was for, and the answer is worth stating plainly: **the `plugin` module covers 34% of its statements.**

Branch coverage reads 100%, which says less than it looks — there is almost nothing branching in the part the tests do reach.

## What I set, and why it is not an endorsement

```scala
ThisBuild / coverageSummaryStmtLowThreshold := 30
ThisBuild / coverageSummaryStmtHighThreshold := 90
ThisBuild / coverageSummaryBranchLowThreshold := 100
ThisBuild / coverageSummaryBranchHighThreshold := 100
```

The floor sits just under where the module stands. It says *do not get worse*; it does not say 34% is fine. The high threshold stays at 90 so every report keeps showing how far off that is, in yellow. Raising the floor is one line once there are tests to justify it — and this is the repository where writing them would pay most, since every other H8IO build depends on this plugin to resolve its dependencies.

## Worth knowing about the check

It is applied **per module**, not to the aggregate. The first attempt set the floor at 35, on the strength of the build total of 35.29%, and failed:

```
[plugin] Statement coverage is 34.00%, below the required 35.00%
```

An unset minimum resolves to the low threshold of its own metric in its own module, so the number to compare against is each module's own, never the total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)