### PR TITLE
Say what the plugin is for

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+`sbt-dependencies` lets a family of artifacts that shares a version state it once. It is one file — three
+implicit classes lifting sbt's dependency syntax from a single `ModuleID` to a `Seq[ModuleID]`:
+
+- `String` gains `%` and `%%` taking a `Seq[String]` of artifact names
+- `Seq[OrganizationArtifactName]` gains `%` taking a version
+- `Seq[ModuleID]` gains everything a single `ModuleID` has — `% configuration`, `cross`, `notTransitive`,
+  `intransitive`, `changing`, `force()`, `artifacts`, `excludeAll`, `exclude`, `extra`, `pomOnly`, `jar`
+
+Every one of them is `map` over a sequence. Nothing is deferred, cached or reinterpreted, and the result is
+ordinary dependencies. Keeping it that way is the point: a build that uses this should be indistinguishable
+from one that spells its dependencies out.
+
+**It is not an `AutoPlugin`.** There are no settings and nothing to enable — `addSbtPlugin` only puts the
+package on the build's classpath, and `import h8io.sbt.dependencies.*` brings the syntax into scope. A reader
+looking for `projectSettings` will not find any.
+
+`stages`, `cfg`, `xi`, `reflect` and the `h8io.g8` template all declare their dependencies through it, so a
+change here reaches every H8IO build.
+
+## Commands
+
+```bash
+sbt +test                    # both rows of the matrix
+sbt "plugin2_12/test"        # one row: sbt 1 on Scala 2.12
+sbt "plugin/test"            # the other: sbt 2 on Scala 3
+sbt scalafmtAll scalafmtSbt  # format
+./test.sh                    # everything CI runs
+```
+
+## The matrix
+
+`projectMatrix` builds two rows: Scala 2.12 published for sbt 1, Scala 3 published for sbt 2. `baseDirectory`
+is virtual (`.sbt/matrix/plugin2_12`), so anything deriving paths from it needs checking against both rows.
+
+Unlike `h8io/sbt-testkit`, there is **no version-specific source directory here** — the whole plugin compiles
+unchanged on both rows, because it touches only `ModuleID`, `Configuration` and `ExclusionRule`, whose shape did
+not change between sbt 1 and sbt 2. That is a property worth keeping: reaching for an API that differs between
+the two would mean introducing a compat split for a file this small.
+
+## Coverage, and what is missing
+
+The gate is `coverageSummaryStmtLowThreshold := 30`, high at 90, branch at 100/100. The build measures **34%
+of statements**, and the floor sits just under that: it says *do not get worse*, not that 34% is acceptable.
+
+What is untested is specific and easy. `PackageTest` covers the three ways to build a sequence — one
+organization with many artifacts, many organizations with one version, and a configuration applied to the
+group. It covers **none** of the other eleven modifiers on `Seq[ModuleID]`, which is the whole of the gap. They
+are all the same one line, `apply(_.someModuleIdMethod)`, so each is a short test of the same shape as the
+existing ones, and writing them would take the number close to 100 in one sitting.
+
+Branch coverage reads 100%, which says less than it looks: there is almost nothing branching in what the tests
+reach.
+
+**The check is per module, not on the aggregate.** The build totals 35.29% while the `plugin` module that the
+gate actually judges is at 34%. An unset minimum resolves to the low threshold of its own metric in its own
+module, so the number to compare against is always the module's own.
+
+## Releasing
+
+The README pins a version in its install snippet and nothing checks it. Bump it as part of the release rather
+than after it.
+
+## Style
+
+- Warnings are fatal on both rows, including unused imports — an `import sbt.*` left behind after an edit fails
+  the build rather than warning.
+- `scalafmt` covers `.sbt` files too (`scalafmtSbtCheck`), and CI checks both.

--- a/README.md
+++ b/README.md
@@ -1,40 +1,88 @@
+[![GitHub release](https://img.shields.io/github/v/release/h8io/sbt-dependencies)](https://github.com/h8io/sbt-dependencies/releases/latest)
+
 # sbt-dependencies
 
-SBT dependencies groups helper.
+State a version once for a family of artifacts that has to move together.
+
+## The problem
+
+Libraries rarely arrive alone. Spark is three or four artifacts, Jackson is several, JUnit is a handful — and
+they share a version not by coincidence but by requirement. Written out one line at a time, the version is
+repeated as many times as there are artifacts:
+
+```scala
+libraryDependencies ++= Seq(
+  "org.apache.spark" %% "spark-core" % "3.3.1",
+  "org.apache.spark" %% "spark-sql" % "3.3.1",
+  "org.apache.spark" %% "spark-streaming" % "3.3.1"
+)
+```
+
+Every bump is then three edits instead of one, and nothing notices when it is two. A family that drifts apart
+fails at runtime, on a `NoSuchMethodError` far from the line that caused it.
 
 ## Usage
 
-### plugins.sbt
-
 ```scala
-addSbtPlugin("io.h8.sbt" %% "sbt-dependencies" % "x.x.x")
+// project/plugins.sbt
+addSbtPlugin("io.h8.sbt" %% "sbt-dependencies" % "1.1.1")
 ```
 
-[![GitHub release](https://img.shields.io/github/v/release/h8io/sbt-dependencies)](https://github.com/h8io/sbt-dependencies/releases/latest)
-
-### build.sbt
-
-Import the package `h8io.sbt.dependencies.*`
-
-Add group dependencies:
-
 ```scala
-libraryDependencies ++= (
-  Seq(
-    "com.fasterxml.jackson.core" % "jackson-databind",
-    "com.fasterxml.jackson.core" % "jackson-core",
-    "com.fasterxml.jackson.module" %% "jackson-module-scala"
-  ) % "2.14.1") ++ (
-  "org.apache.spark" %% Seq(
-    "spark-core",
-    "spark-sql",
-    "spark-streaming"
-  ) % "3.3.1") ++ (
-  "org.junit.jupiter" % Seq(
-    "junit-jupiter-api",
-    "junit-jupiter-engine",
-    "junit-jupiter-params"
-  ) % "5.9.1" % Test)
+// build.sbt
+import h8io.sbt.dependencies.*
 ```
 
-Other modules modifiers (like `exclude`, `excludeAll` or `force`) are applicable too.
+### One organization, several artifacts
+
+```scala
+libraryDependencies ++= "org.apache.spark" %% Seq("spark-core", "spark-sql", "spark-streaming") % "3.3.1"
+```
+
+`%` and `%%` both work, and mean what they always mean — whether the Scala version is part of the artifact name.
+
+### Several organizations, one version
+
+Some families are split across organizations while still sharing a version:
+
+```scala
+libraryDependencies ++= Seq(
+  "com.fasterxml.jackson.core" % "jackson-databind",
+  "com.fasterxml.jackson.core" % "jackson-core",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala"
+) % "2.14.1"
+```
+
+Each entry chooses its own `%` or `%%`; the version applies to all of them.
+
+### Modifiers apply to the group
+
+Anything you would write on a single `ModuleID` can be written once for the sequence:
+
+```scala
+libraryDependencies ++= "org.junit.jupiter" % Seq(
+  "junit-jupiter-api",
+  "junit-jupiter-engine",
+  "junit-jupiter-params"
+) % "5.9.1" % Test
+
+libraryDependencies ++= "org.apache.spark" %% Seq("spark-core", "spark-sql") % "3.3.1" %
+  Provided excludeAll ExclusionRule("org.slf4j")
+```
+
+Available on the group: `% configuration`, `cross`, `notTransitive`, `intransitive`, `changing`, `force()`,
+`artifacts`, `excludeAll`, `exclude`, `extra`, `pomOnly`, `jar`.
+
+## What it is not
+
+An extension of sbt's dependency model. Everything here is `map` over a `Seq[ModuleID]`, so what comes out is
+ordinary dependencies that resolve, exclude and cross-build exactly as they would written one per line. Nothing
+is deferred, cached or reinterpreted — the only thing that changes is how many times you type the version.
+
+## sbt versions
+
+Published for both sbt 1.x and sbt 2.x; `addSbtPlugin` resolves the right one.
+
+## License
+
+Apache-2.0. See `LICENSE`.

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val plugin = projectMatrix.in(file("plugin"))
     organizationName := "H8IO",
     organizationHomepage := Some(url("https://github.com/h8io/")),
     description := "SBT dependencies helper",
-    licenses := List("Apache 2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
+    licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
     homepage := Some(url("https://github.com/h8io/sbt-dependencies")),
     versionScheme := Some("semver-spec"),
     javacOptions ++= Seq("--release", "11"),
@@ -19,7 +19,7 @@ val plugin = projectMatrix.in(file("plugin"))
         id = "eshu",
         name = "Pavel",
         email = "tjano.xibalba@gmail.com",
-        url = url("https://github.com/h8io/")
+        url = url("https://github.com/eshu/")
       )
     ),
     scmInfo := Some(


### PR DESCRIPTION
## README

It said *"SBT dependencies groups helper"* and showed the syntax — what the plugin types, rather than why you would want it.

The reason is that a family of artifacts shares a version **by requirement, not by coincidence**. Written a line at a time, the version is repeated once per artifact, every bump is that many edits, and nothing notices when it is one fewer. A family that drifts apart fails at runtime, on a `NoSuchMethodError` far from the line that caused it.

The README now leads with that, then shows the three shapes — one organisation with many artifacts, many organisations with one version, and modifiers applied to the whole group — and ends with what the plugin deliberately is *not*: everything is `map` over a `Seq[ModuleID]`, so the result is ordinary dependencies that resolve exactly as they would written out.

**Every snippet was compiled before being written down**, against the published 1.1.1, including the chain ending in `% Provided excludeAll ExclusionRule("org.slf4j")`. They produce what the text claims:

```
* org.apache.spark:spark-core:3.3.1
* com.fasterxml.jackson.core:jackson-core:2.14.1
* org.junit.jupiter:junit-jupiter-api:5.9.1:test
* org.apache.spark:spark-core:3.3.1:provided
```

The install snippet also stops saying `x.x.x` and names 1.1.1.

## CLAUDE.md

What is not visible from the source:

- **It is not an `AutoPlugin`.** No settings, nothing to enable — `addSbtPlugin` puts the package on the classpath and the import brings the syntax. Someone looking for `projectSettings` will not find any.
- **There is no compat split**, unlike `sbt-testkit`, because the plugin only touches `ModuleID`, `Configuration` and `ExclusionRule`, whose shape did not change between sbt 1 and sbt 2. Worth keeping: reaching for an API that differs would mean introducing a split for a file this small.
- **The untested third is specific.** `PackageTest` covers the three ways to build a sequence and none of the eleven modifiers on `Seq[ModuleID]`. They are all one line of the same shape, so each is a short test like the ones already there, and writing them would take coverage close to 100 in one sitting.
- The coverage check is **per module**, not on the aggregate — 35.29% for the build, 34% for the module the gate judges.

## Two things that were wrong

`licenses` said `"Apache 2"` where the rest of the organisation says the SPDX `"Apache-2.0"`, and `developers`.url pointed at the organisation instead of the person. Both go into the POM of every release. Same pair as h8io/sbt-testkit#29 fixed.

`./test.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)