### PR TITLE
Cover the eleven modifiers, and hold the build to it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,23 +43,25 @@ unchanged on both rows, because it touches only `ModuleID`, `Configuration` and 
 not change between sbt 1 and sbt 2. That is a property worth keeping: reaching for an API that differs between
 the two would mean introducing a compat split for a file this small.
 
-## Coverage, and what is missing
+## Coverage
 
-The gate is `coverageSummaryStmtLowThreshold := 30`, high at 90, branch at 100/100. The build measures **34%
-of statements**, and the floor sits just under that: it says *do not get worse*, not that 34% is acceptable.
+100% of statements and of branches, with the gate at `low = high = 100` on both metrics. Every modifier on
+`Seq[ModuleID]` is one line delegating to its `ModuleID` counterpart, so there is no part of this that is
+awkward to reach and no reason for the number to be anything else.
 
-What is untested is specific and easy. `PackageTest` covers the three ways to build a sequence — one
-organization with many artifacts, many organizations with one version, and a configuration applied to the
-group. It covers **none** of the other eleven modifiers on `Seq[ModuleID]`, which is the whole of the gap. They
-are all the same one line, `apply(_.someModuleIdMethod)`, so each is a short test of the same shape as the
-existing ones, and writing them would take the number close to 100 in one sitting.
+The tests for the modifiers state the same thing eleven times: applying it to the group equals mapping it over
+the members. The expected side writes the function out rather than reusing the one under test, which is what
+makes a modifier delegating to the wrong one of its neighbours — `jar` to `pomOnly()`, say — fail rather than
+pass.
 
-Branch coverage reads 100%, which says less than it looks: there is almost nothing branching in what the tests
-reach.
+**The check is per module, not on the aggregate.** That mattered while this build was under the bar: it totalled
+35.29% while the `plugin` module the gate judges stood at 34%, and a floor set from the total failed. An unset
+minimum resolves to the low threshold of its own metric in its own module, so the number to compare against is
+always the module's own.
 
-**The check is per module, not on the aggregate.** The build totals 35.29% while the `plugin` module that the
-gate actually judges is at 34%. An unset minimum resolves to the low threshold of its own metric in its own
-module, so the number to compare against is always the module's own.
+Note that `-Wsafe-init` on the Scala 3 row reacts to instance fields in a ScalaTest class: adding a
+`private val` to `PackageTest` made the checker report the *first* test in the file, one untouched by the
+change. The helpers are `private def` for that reason.
 
 ## Releasing
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-ThisBuild / coverageSummaryStmtLowThreshold := 30
-ThisBuild / coverageSummaryStmtHighThreshold := 90
+ThisBuild / coverageSummaryStmtLowThreshold := 100
+ThisBuild / coverageSummaryStmtHighThreshold := 100
 ThisBuild / coverageSummaryBranchLowThreshold := 100
 ThisBuild / coverageSummaryBranchHighThreshold := 100
 

--- a/plugin/src/test/scala/h8io/sbt/dependencies/PackageTest.scala
+++ b/plugin/src/test/scala/h8io/sbt/dependencies/PackageTest.scala
@@ -40,4 +40,53 @@ class PackageTest extends AnyFlatSpec with Matchers {
       "org.junit.jupiter" % "junit-jupiter-params" % "5.9.1" % Test
     )
   }
+
+  /** Every modifier on the sequence is the same modifier applied to each module, so that is what these state. The
+    * function is written out on the right rather than reused from the left, which is what makes a modifier delegating
+    * to the wrong one of its neighbours fail here.
+    */
+  private def group = "org.apache.spark" %% Seq("spark-core", "spark-sql") % "3.3.1"
+
+  private def modules =
+    List("org.apache.spark" %% "spark-core" % "3.3.1", "org.apache.spark" %% "spark-sql" % "3.3.1")
+
+  private def behavesLike(actual: Seq[ModuleID])(expected: ModuleID => ModuleID) =
+    actual should contain theSameElementsInOrderAs modules.map(expected)
+
+  it should "cross-version every module" in
+    behavesLike(group.cross(CrossVersion.full))(_.cross(CrossVersion.full))
+
+  it should "make every module non-transitive" in
+    behavesLike(group.notTransitive)(_.notTransitive())
+
+  it should "make every module intransitive" in
+    behavesLike(group.intransitive)(_.intransitive())
+
+  it should "mark every module as changing" in
+    behavesLike(group.changing)(_.changing())
+
+  it should "force the version of every module" in
+    behavesLike(group.force())(_.force())
+
+  it should "give every module the same artifacts" in {
+    val artifact = Artifact("spark", "sources")
+    behavesLike(group.artifacts(artifact))(_.artifacts(artifact))
+  }
+
+  it should "apply the same exclusion rules to every module" in {
+    val rule = ExclusionRule("org.slf4j")
+    behavesLike(group.excludeAll(rule))(_.excludeAll(rule))
+  }
+
+  it should "exclude the same dependency from every module" in
+    behavesLike(group.exclude("org.slf4j", "slf4j-api"))(_.exclude("org.slf4j", "slf4j-api"))
+
+  it should "attach the same extra attributes to every module" in
+    behavesLike(group.extra("key" -> "value"))(_.extra("key" -> "value"))
+
+  it should "reduce every module to its pom" in
+    behavesLike(group.pomOnly)(_.pomOnly())
+
+  it should "reduce every module to its jar" in
+    behavesLike(group.jar)(_.jar())
 }


### PR DESCRIPTION
## What was missing

`PackageTest` covered the three ways to build a sequence — one organisation with many artifacts, many organisations with one version, a configuration applied to the group — and **none** of the eleven modifiers on `Seq[ModuleID]`. That was the whole of the 34%.

## The tests

Eleven, one per modifier, stating the same thing each time: applying it to the group equals mapping it over the members.

```scala
private def behavesLike(actual: Seq[ModuleID])(expected: ModuleID => ModuleID) =
  actual should contain theSameElementsInOrderAs modules.map(expected)

it should "reduce every module to its jar" in
  behavesLike(group.jar)(_.jar())
```

The expected side writes the function out rather than reusing the one under test. That is what makes a modifier delegating to the wrong one of its neighbours — `jar` to `pomOnly()`, say — fail rather than pass.

## Coverage

**34% → 100%** of statements, branches stay at 100%, and the thresholds move to `low = high = 100` on both metrics, matching `stages`, `cfg` and `xi`.

Checked that the gate bites rather than merely running — the first attempt at this check silently changed nothing, because `scalafmt` had removed the braces I was matching on and the test was never actually deleted. Done properly, with one test removed:

```
Tests: succeeded 13
Statement coverage.: 94.12%
[error] [plugin2_12] Statement coverage is 94.29%, below the required 100.00%
```

## One thing worth knowing

The helpers are `private def`, not `private val`. `-Wsafe-init` on the Scala 3 row reports the **first** test in the file — one this change does not touch — the moment the class gains an instance field, because ScalaTest's `should … in` runs in the constructor. `def` keeps the class field-free. `CLAUDE.md` records it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)